### PR TITLE
Use a two-stage build and a smaller base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ COPY --from=builder /root/.local /root/.local
 
 WORKDIR /app
 COPY main.py /app
+ENV PATH=/root/.local:$PATH
+
 ENTRYPOINT [ "python", "-u", "main.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM ubuntu:20.04
+FROM python:3.10.0-alpine AS builder
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip && pip3 install --user --no-cache-dir -r /tmp/requirements.txt
 
-RUN apt update && apt install -y \
-      python3 python3-pip
-
-COPY requirements.txt app/requirements.txt
+FROM python:3.10.0-alpine
+COPY --from=builder /root/.local /root/.local
 
 WORKDIR /app
-RUN pip3 install -r requirements.txt
-
 COPY main.py /app
-
-CMD python3 -u main.py
+ENTRYPOINT [ "python", "-u", "main.py" ]


### PR DESCRIPTION
Reduces final image size from 414MB to 48MB